### PR TITLE
Add manual deployment for backend

### DIFF
--- a/.github/workflows/manual-deployment.yml
+++ b/.github/workflows/manual-deployment.yml
@@ -1,0 +1,38 @@
+# This workflow manually deploys SauNah backend from the tag given
+# to either staging or production
+
+name: Build, Test & Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      containerTag:
+        type: string
+        description: Container Tag
+        required: true
+      deploymentEnv:
+        type: choice
+        description: Deployment Environment
+        required: true
+        options:
+          - staging
+          - prod
+        default: staging
+
+jobs:
+  values:
+    name: Setup Configuration Values
+    uses: ./.github/workflows/values.yml
+    with:
+      deploymentEnv: ${{ inputs.deploymentEnv }}
+
+  deploy:
+    name: Deploy Container to Kubernetes Cluster
+    needs: [values]
+    uses: ./.github/workflows/deploy.yml
+    with:
+      containerTag: ${{ github.event.inputs.containerTag }}
+      context: ${{ needs.values.outputs.k8sContext }}
+      valuesName: ${{ needs.values.outputs.k8sConfigValues }}
+    secrets:
+      k8sConfig: ${{ secrets.K8S_CONFIG }}

--- a/.github/workflows/manual-deployment.yml
+++ b/.github/workflows/manual-deployment.yml
@@ -24,7 +24,7 @@ jobs:
     name: Setup Configuration Values
     uses: ./.github/workflows/values.yml
     with:
-      deploymentEnv: ${{ inputs.deploymentEnv }}
+      deploymentEnv: ${{ github.event.inputs.deploymentEnv }}
 
   deploy:
     name: Deploy Container to Kubernetes Cluster

--- a/.github/workflows/manual-deployment.yml
+++ b/.github/workflows/manual-deployment.yml
@@ -1,7 +1,7 @@
 # This workflow manually deploys SauNah backend from the tag given
 # to either staging or production
 
-name: Manual Deployment (untested)
+name: Manual Deployment
 
 on:
   workflow_dispatch:

--- a/.github/workflows/manual-deployment.yml
+++ b/.github/workflows/manual-deployment.yml
@@ -1,7 +1,7 @@
 # This workflow manually deploys SauNah backend from the tag given
 # to either staging or production
 
-name: Build, Test & Deploy
+name: Manual Deployment (untested)
 
 on:
   workflow_dispatch:

--- a/.github/workflows/run-deployment.yml
+++ b/.github/workflows/run-deployment.yml
@@ -15,6 +15,8 @@ jobs:
   values:
     name: Setup Configuration Values
     uses: ./.github/workflows/values.yml
+    with:
+      deploymentEnv: auto
 
   build:
     name: Build & Run Tests with Gradle

--- a/.github/workflows/values.yml
+++ b/.github/workflows/values.yml
@@ -2,6 +2,10 @@ name: Setup values
 
 on:
   workflow_call:
+    inputs:
+      deploymentEnv:
+        required: true
+        type: string
     outputs:
       containerTag:
         value: ${{ jobs.setup.outputs.containerTag }}
@@ -18,19 +22,31 @@ jobs:
       containerTag: ${{ steps.setConfigs.outputs.containerTag }}
       k8sContext: ${{ steps.setConfigs.outputs.k8sContext }}
       k8sConfigValues: ${{ steps.setConfigs.outputs.k8sConfigValues }}
-      deploymentEnv: ${{ steps.setConfigs.outputs.deploymentEnv }}
     steps:
     - uses: actions/checkout@v2
     - name: Set Tag Ouput Variable
       id: setConfigs
       run: |
-        if [ "${{ github.ref_type }}" == "tag" ]
+        DEPLOYMENT_ENV="${{ inputs.deploymentEnv }}"
+
+        if [ "$DEPLOYMENT_ENV" == "auto" ]
         then
-          echo "::set-output name=containerTag::${{ github.ref_name }}"
+          if [ "${{ github.ref_type }}" == "tag" ]
+          then
+            DEPLOYMENT_ENV="prod"
+            echo "::set-output name=containerTag::${{ github.ref_name }}"
+          else
+            DEPLOYMENT_ENV="staging"
+            echo "::set-output name=containerTag::$(echo ${{ github.sha }} | cut -c 1-7)"
+          fi
+        fi
+
+        if [ "$DEPLOYMENT_ENV" == "prod" ]
+        then
           echo "::set-output name=k8sContext::init-lab-prod"
           echo "::set-output name=k8sConfigValues::values-prod.yaml"
-        else
-          echo "::set-output name=containerTag::$(echo ${{ github.sha }} | cut -c 1-7)"
+        elif [ "$DEPLOYMENT_ENV" == "staging" ]
+        then
           echo "::set-output name=k8sContext::init-lab-staging"
           echo "::set-output name=k8sConfigValues::values-staging.yaml"
         fi


### PR DESCRIPTION
## Summary

- Adds a build pipeline which can manually be triggered to deploy the backend from the container tag specified to either staging or production.


## Related Issues

- Closes #23 


## Definition of Done

- User story
  - [x] All stated conditions fulfilled
- Code
  - [x] No more code needed
  - [x] No known bugs
- Clean Code
  - ~JavaDoc has been added~
  - ~API documentation has been added via annotations (if applicable)~
  - ~No unavoidable code smells~
- Testing
  - [x] All existing tests pass
  - ~New unit tests created according to [CONTRIBUTING.md](./CONTRIBUTING.md#-testing-strategy)~
  - ~New unit tests pass~
- SonarCloud
  - [x] Quality gate passed
- Compatibility to frontend
  - ~Compatibility to staging-frontend verified (running frontend locally in Docker container with image matching the deployed image on staging)~
