### PR TITLE
Add placeholder job for manual deployment

### DIFF
--- a/.github/workflows/manual-deployment.yml
+++ b/.github/workflows/manual-deployment.yml
@@ -1,0 +1,18 @@
+# This workflow manually deploys SauNah backend from the tag given
+# to either staging or production
+# This implementation is a placeholder on the main branch
+# to allow developing and testing on another branch.
+
+name: Manual Deployment (placeholder)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  placeholder:
+    name: Placeholder Job
+    runs-on: ubuntu-latest
+    steps:
+    - name: Placeholder
+      run: |
+        echo "Placeholder"


### PR DESCRIPTION
## Summary

- This adds a placeholder pipeline. This is necessary as pipelines can only be triggered manually when the action exists on the main branch. As soon as it exists, it can also be run from another branch. Thus, this is a placeholder which can be merged to main, which then allows to implement the real feature in #24 and test it properly before merging to main.


## Related Issues


## Definition of Done

- User story
  - [x] All stated conditions fulfilled
- Code
  - [ ] No more code needed
  - [ ] No known bugs
- Clean Code
  - [ ] JavaDoc has been added
  - [ ] API documentation has been added via annotations (if applicable)
  - [ ] No unavoidable code smells
- Testing
  - [ ] All existing tests pass
  - [ ] New unit tests created according to [CONTRIBUTING.md](./CONTRIBUTING.md#-testing-strategy)
  - [ ] New unit tests pass
- SonarCloud
  - [ ] Quality gate passed
- Compatibility to frontend
  - [ ] Compatibility to staging-frontend verified (running frontend locally in Docker container with image matching the deployed image on staging)
