### PR TITLE
Environment variable for extra cors

### DIFF
--- a/helm/saunah-backend/values-local.yaml
+++ b/helm/saunah-backend/values-local.yaml
@@ -25,6 +25,8 @@ env:
     value: saunah
   - name: SAUNAH_FRONTEND_BASE_URL
     value: "http://localhost:8889"
+  - name: SAUNAH_EXTRA_ALLOWED_CORS
+    value: ""
   - name: SAUNAH_SMTP_HOST
     value: smtp.mailtrap.io
   - name: SAUNAH_SMTP_PORT

--- a/helm/saunah-backend/values-prod.yaml
+++ b/helm/saunah-backend/values-prod.yaml
@@ -25,6 +25,8 @@ env:
     value: saunah
   - name: SAUNAH_FRONTEND_BASE_URL
     value: "https://saunah.k8s.init-lab.ch"
+  - name: SAUNAH_EXTRA_ALLOWED_CORS
+    value: "http://localhost:3000"
   - name: SAUNAH_SMTP_HOST
     value: smtp.mailersend.net
   - name: SAUNAH_SMTP_PORT

--- a/helm/saunah-backend/values-staging.yaml
+++ b/helm/saunah-backend/values-staging.yaml
@@ -25,6 +25,8 @@ env:
     value: saunah
   - name: SAUNAH_FRONTEND_BASE_URL
     value: "https://saunah-staging.k8s.init-lab.ch"
+  - name: SAUNAH_EXTRA_ALLOWED_CORS
+    value: "http://localhost:3000"
   - name: SAUNAH_SMTP_HOST
     value: smtp.mailtrap.io
   - name: SAUNAH_SMTP_PORT

--- a/src/main/java/ch/saunah/saunahbackend/configuration/SaunahBackendConfiguration.java
+++ b/src/main/java/ch/saunah/saunahbackend/configuration/SaunahBackendConfiguration.java
@@ -1,8 +1,12 @@
 package ch.saunah.saunahbackend.configuration;
 
+import java.util.Arrays;
+import java.util.stream.Stream;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.Nullable;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -17,12 +21,17 @@ public class SaunahBackendConfiguration {
     @Value("${saunah.version}")
     private String version;
 
+    @Nullable
+    @Value("${saunah.extra-allowed-cors}")
+    private String extraAllowedCors;
+
     @Bean
     public WebMvcConfigurer corsConfigurer() {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/**").allowedOrigins(frontendBaseUrl); //wieso localhost:3000? zum testen musste ich es auf localhost:8080 setzen.
+                registry.addMapping("/**").allowedOrigins(
+                    getAllowedCors(frontendBaseUrl, extraAllowedCors));
             }
         };
     }
@@ -36,5 +45,18 @@ public class SaunahBackendConfiguration {
                     .description("Documentation of API Routes for the SauNah backend.")
                     .version(version)
             );
+    }
+
+    /**
+     * Get all allowed CORS, which includes frontend URL
+     * and extra allowed cors defined.
+     * @return
+     */
+    public static String[] getAllowedCors(String frontend, @Nullable String extra) {
+        Stream<String> frontendStream = Stream.of(frontend.trim());
+        Stream<String> extraStream = Arrays.stream(
+            (extra != null && !extra.isEmpty()) ? extra.split(",") : new String[]{})
+            .map(String::trim);
+        return Stream.concat(frontendStream, extraStream).toArray(String[]::new);
     }
 }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -23,5 +23,10 @@
     "name": "saunah.email.from.name",
     "type": "java.lang.String",
     "description": "The name which is listed as the sender name."
+  },
+  {
+    "name": "saunah.extra-allowed-cors",
+    "type": "java.lang.String",
+    "description": "Comma separated list of additional allowed CORS urls.'"
   }
 ]}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,6 +16,7 @@ springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/api-docs/swagger
 springdoc.api-docs.enabled=true
 saunah.frontend.baseurl=${SAUNAH_FRONTEND_BASE_URL}
+saunah.extra-allowed-cors=${SAUNAH_EXTRA_ALLOWED_CORS:#{null}}
 saunah.version=0.1.0
 saunah.email.from.email=noreply@saunah.ch
 saunah.email.from.name=SauNah

--- a/src/test/java/ch/saunah/saunahbackend/configuration/SaunahBackendConfigurationTest.java
+++ b/src/test/java/ch/saunah/saunahbackend/configuration/SaunahBackendConfigurationTest.java
@@ -15,13 +15,32 @@ class SaunahBackendConfigurationTest {
     private static final String[] EXTRA_CORS = new String[]{"https://localhost:3000", "https://localhost:3001"};
 
     @Test
-    void testGetAllowedCors() {
+    void testExtraCorsSet() {
         String[] actualCors = SaunahBackendConfiguration.getAllowedCors(
             FRONTEND_URL, String.join(",", EXTRA_CORS));
 
         String[] expectedCors = Stream.concat(
             Stream.of(FRONTEND_URL), Arrays.stream(EXTRA_CORS))
             .toArray(String[]::new);
+
+        assertArrayEquals(expectedCors, actualCors);
+    }
+
+    @Test
+    void testExtraCorsEmpty() {
+        String[] actualCors = SaunahBackendConfiguration.getAllowedCors(
+            FRONTEND_URL, String.join(",", ""));
+
+        String[] expectedCors = new String[]{FRONTEND_URL};
+
+        assertArrayEquals(expectedCors, actualCors);
+    }
+
+    @Test
+    void testExtraCorsNull() {
+        String[] actualCors = SaunahBackendConfiguration.getAllowedCors(
+            FRONTEND_URL, null);
+        String[] expectedCors = new String[]{FRONTEND_URL};
 
         assertArrayEquals(expectedCors, actualCors);
     }

--- a/src/test/java/ch/saunah/saunahbackend/configuration/SaunahBackendConfigurationTest.java
+++ b/src/test/java/ch/saunah/saunahbackend/configuration/SaunahBackendConfigurationTest.java
@@ -1,0 +1,30 @@
+package ch.saunah.saunahbackend.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class SaunahBackendConfigurationTest {
+
+    private static final String FRONTEND_URL = "https://booking.saunah.ch";
+    private static final String[] EXTRA_CORS = new String[]{"https://localhost:3000", "https://localhost:3001"};
+
+    @Test
+    void testGetAllowedCors() {
+        String[] actualCors = SaunahBackendConfiguration.getAllowedCors(
+            FRONTEND_URL, String.join(",", EXTRA_CORS));
+
+        String[] expectedCors = Stream.concat(
+            Stream.of(FRONTEND_URL), Arrays.stream(EXTRA_CORS))
+            .toArray(String[]::new);
+
+        assertArrayEquals(expectedCors, actualCors);
+    }
+
+}
+

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,6 +1,7 @@
 saunah.version=0.1.0
 saunah.email.from.email=noreply@saunah.ch
 saunah.email.from.name=SauNah
+saunah.extra-allowed-cors=${SAUNAH_EXTRA_ALLOWED_CORS:#{null}}
 spring.datasource.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 saunah.frontend.baseurl=localhost:3000


### PR DESCRIPTION
## Summary

- Enable configuration for additional CORS via environment variable
  - This allows for things such as testing the local frontend with the deployed backend


## Related Issues

- None

## Definition of Done

- User story
  - [x] All stated conditions fulfilled
- Code
  - [x] No more code needed
  - [x] No known bugs
- Clean Code
  - [x] JavaDoc has been added
  - [x] API documentation has been added via annotations (if applicable)
  - [x] No unavoidable code smells
- Testing
  - [x] All existing tests pass
  - [x] New unit tests created according to [CONTRIBUTING.md](./CONTRIBUTING.md#-testing-strategy)
  - [x] New unit tests pass
- SonarCloud
  - [x] Quality gate passed
- Compatibility to frontend
  - [x] Compatibility to staging-frontend verified (running frontend locally in Docker container with image matching the deployed image on staging)
