### PR TITLE
Enquote boolean environment values to fix helm deployment

### DIFF
--- a/helm/saunah-backend/values-local.yaml
+++ b/helm/saunah-backend/values-local.yaml
@@ -56,7 +56,7 @@ env:
         key: googleServiceAccount
         optional: false
   - name: SAUNAH_OBJECT_STORAGE_ENABLE
-    value: true
+    value: "true"
   - name: SAUNAH_OBJECT_STORAGE_BUCKET_ID
     value: saunah-storage-local
   - name: SAUNAH_OBJECT_STORAGE_BUCKET_ENDPOINT

--- a/helm/saunah-backend/values-prod.yaml
+++ b/helm/saunah-backend/values-prod.yaml
@@ -56,7 +56,7 @@ env:
         key: googleServiceAccount
         optional: false
   - name: SAUNAH_OBJECT_STORAGE_ENABLE
-    value: true
+    value: "true"
   - name: SAUNAH_OBJECT_STORAGE_BUCKET_ID
     value: saunah-storage-prod
   - name: SAUNAH_OBJECT_STORAGE_BUCKET_ENDPOINT

--- a/helm/saunah-backend/values-staging.yaml
+++ b/helm/saunah-backend/values-staging.yaml
@@ -56,7 +56,7 @@ env:
         key: googleServiceAccount
         optional: false
   - name: SAUNAH_OBJECT_STORAGE_ENABLE
-    value: true
+    value: "true"
   - name: SAUNAH_OBJECT_STORAGE_BUCKET_ID
     value: saunah-storage-staging
   - name: SAUNAH_OBJECT_STORAGE_BUCKET_ENDPOINT


### PR DESCRIPTION
## Summary

- Fixes broken helm deployment to to `boolean`s not being interpreted correctly as strings
  - add double quotes to fix it
