### PR TITLE
Add google calendar api key

### DIFF
--- a/helm/saunah-secrets/templates/secrets-credentials.yaml
+++ b/helm/saunah-secrets/templates/secrets-credentials.yaml
@@ -5,4 +5,5 @@ metadata:
   namespace: {{ .Values.namespace }}
 data:
   googleServiceAccount: {{ .Values.secrets.credentials.googleServiceAccount }}
+  googleCalendarApiKey: {{ .Values.secrets.credentials.googleCalendarApiKey }}
 type: Opaque


### PR DESCRIPTION
## Summary

- Correctly sets google calendar api key on secrets deployment