### PR TITLE
Remove check whether bucket exists when getting images

### DIFF
--- a/src/main/java/ch/saunah/saunahbackend/util/ImageUploadS3.java
+++ b/src/main/java/ch/saunah/saunahbackend/util/ImageUploadS3.java
@@ -90,9 +90,6 @@ public class ImageUploadS3 implements ImageUpload {
     @Override
     public URL getImageURL(String directory, String filename) throws IOException {
         AmazonS3 client = getObjectStorageClient();
-        if (!client.doesBucketExist(bucket)) {
-            throw new IOException("Bucket does not exist and no image can be found!");
-        }
         return client.getUrl(bucket, getObjectPath(directory, filename));
     }
 
@@ -105,9 +102,6 @@ public class ImageUploadS3 implements ImageUpload {
     public void removeImage(String directory, String fileName) throws IOException {
         try {
         AmazonS3 client = getObjectStorageClient();
-        if (!client.doesBucketExist(bucket)) {
-            throw new IOException("Bucket does not exist and no image can be found!");
-        }
         client.deleteObject(bucket, getObjectPath(directory, fileName));
         } catch (AmazonClientException e) {
             throw new IOException(e.getMessage());


### PR DESCRIPTION
## Summary

- This removes the check `client.doesBucketExist(bucket)` when getting images, as this takes a lot of time. This will not be a big problem, as case of the bucket not existing, it will just return an invalid URL. Just constructing the URL does not involve a network request, which is the part that seems to take quite long sometimes.